### PR TITLE
Fixes for Windows

### DIFF
--- a/main.php
+++ b/main.php
@@ -43,7 +43,9 @@
 
 require __DIR__ . '/thirdparty/php-markdown/Michelf/Markdown.php';
 
-set_include_path(get_include_path() . ':' . __DIR__ . '/lib');
+set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/lib');
+set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/lib/mathb');
+
 spl_autoload_register();
 
 use MathB\MathB;

--- a/mathbin.php
+++ b/mathbin.php
@@ -43,7 +43,8 @@
 
 require __DIR__ . '/thirdparty/php-markdown/Michelf/Markdown.php';
 
-set_include_path(get_include_path() . ':' . __DIR__ . '/lib');
+set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/lib');
+set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/lib/mathb');
 spl_autoload_register();
 
 use Susam\Session;


### PR DESCRIPTION
The path separator for windows is `;` as opposed to `:`.

Making these changes means that one can run mathb.in on Windows.
