### PR TITLE
Update mathbin.php to fix "Fatal error - Interface not found" while including php-markdown

### DIFF
--- a/mathbin.php
+++ b/mathbin.php
@@ -41,7 +41,7 @@
  */
 
 
-require __DIR__ . '/thirdparty/php-markdown/Michelf/Markdown.php';
+require __DIR__ . '/thirdparty/php-markdown/Michelf/Markdown.inc.php';
 
 set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/lib');
 spl_autoload_register();


### PR DESCRIPTION
Original line causes error on some configurations.